### PR TITLE
Fix KDE connector handling and support keeping displays enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,35 @@ You can achieve the same result by editing `~/.config/sunshine/sunshine.conf`:
 ```conf
 global_prep_cmd = [{"do":"sh -c \"/path/to/dpa do\"","undo":"sh -c \"/path/to/dpa undo\""}]
 ```
+
+The display variables must be available to the Sunshine process. Putting them
+in `~/.profile` only works when Sunshine is launched from a login shell; it is
+not reliable for a `systemd --user` Sunshine service. For a user service, use a
+small wrapper and reference the wrapper from Sunshine:
+
+```bash
+#!/usr/bin/env bash
+export DEFAULT_SEAT_DISPLAY=DP-2
+export DEFAULT_STREAM_DISPLAY=HDMI-A-2
+export DEFAULT_KEEP_DISPLAYS="DP-2 HDMI-A-1"
+export DEFAULT_RESOLUTION=2560x1440
+export DEFAULT_REFRESH_RATE=165
+export DEFAULT_VRR_MODE=automatic
+export DEFAULT_HDR=disable
+exec /path/to/dpa "$@"
+```
+
+Save it as `~/.local/bin/dpa-sunshine`, make it executable, and use it in the
+Sunshine preparation command:
+
+```conf
+global_prep_cmd = [{"do":"sh -c \"$HOME/.local/bin/dpa-sunshine do\"","undo":"sh -c \"$HOME/.local/bin/dpa-sunshine undo\""}]
+```
+
+Alternatively, import variables into the user manager before starting
+Sunshine, or use `~/.config/environment.d/` and log in again. The wrapper is
+preferred because it keeps the display configuration next to the commands
+that use it.
 ### Overriding the client resolution
 
 To have a different resolution for a specific app, add the script as the application-specific do/undo command, with the added `--res-override=WIDTHxHEIGHT` parameter and untick the "Global Prep Commands":
@@ -63,6 +92,10 @@ DEFAULT_RESOLUTION=2560x1440
 DEFAULT_REFRESH_RATE=240 # The refresh rate to attempt to set when quitting the stream session
 DEFAULT_VRR_MODE=automatic # VRR Mode, A.K.A Freesync/GSync
 ```
+
+These variables are suitable for interactive shell use. When Sunshine runs as
+a `systemd --user` service, provide them through a wrapper as described above
+instead of relying only on `~/.profile`.
 
 In case you only have one output/monitor, you can leave `DEFAULT_STREAM_DISPLAY` unset, automatic detection will occur and treat `DEFAULT_SEAT_DISPLAY` as the stream output.
 

--- a/dpa
+++ b/dpa
@@ -69,6 +69,7 @@ readonly _seat_resolution="${DEFAULT_RESOLUTION:-1920x1080}"
 readonly _seat_refresh_rate="${DEFAULT_REFRESH_RATE:-60}"
 readonly _default_vrr_mode="${DEFAULT_VRR_MODE:-never}"
 readonly _default_hdr="${DEFAULT_HDR:-disable}"
+_keep_displays="${DEFAULT_KEEP_DISPLAYS:-}"
 _seat_display="${DEFAULT_SEAT_DISPLAY:-DP-3}"
 _stream_display="${DEFAULT_STREAM_DISPLAY:-HDMI-A-1}"
 _client_height="${SUNSHINE_CLIENT_HEIGHT:-720}"
@@ -84,6 +85,7 @@ _res_override=''
 function get_connectors_list() {
 	for edid in /sys/class/drm/card*-*-*/; do
 		case "${edid}" in *-Writeback-*) continue ;; *) ;; esac
+		[[ $(<"${edid}"/status) == "connected" ]] || continue
 		edid="${edid%/}"      # Remove trailing slash
 		edid="${edid##*/}"    # Get basename
 		echo "${edid#card*-}" # Remove card*- prefix using glob pattern
@@ -133,8 +135,12 @@ function KDE::do() {
 	mapfile -t all_connectors < <(get_connectors_list) || true
 	for connector in "${all_connectors[@]}"; do
 		if [[ ${connector} != "${_stream_display}" ]]; then
+			if [[ " ${_keep_displays} " == *" ${connector} "* ]]; then
+				log::info "Keeping ${connector} enabled"
+				continue
+			fi
 			log::info "Disabling ${connector}"
-			log::info "$(kscreen-doctor output."${connector}".disable))"
+			log::info "$(kscreen-doctor output."${connector}".disable)"
 		fi
 	done
 }
@@ -142,6 +148,8 @@ function KDE::undo() {
 	log::info "Restoring ${_seat_display} to default configuration"
 	log::info "Enabling ${_seat_display}"
 	kscreen-doctor output."${_seat_display}".enable
+	log::info "Making ${_seat_display} the primary display"
+	kscreen-doctor output."${_seat_display}".primary
 	log::info "Switching ${_seat_display} to ${_seat_resolution}@${_seat_refresh_rate}"
 	kscreen-doctor output."${_seat_display}".mode."${_seat_resolution}"@"${_seat_refresh_rate}"
 	log::info "Configuring HDR/WCG/VRR for ${_seat_display}"
@@ -296,7 +304,7 @@ generic::x11::undo() {
 	log::info "UNIMPLEMENTED"
 }
 function handle_arguments() {
-	Handle client resolution override via a command-line parameter
+	# Handle client resolution override via a command-line parameter
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 			-r|--res-override)
@@ -336,6 +344,7 @@ function mainloop() {
 	_client_width=${_client_width}
 	_client_refresh_rate=${_client_refresh_rate}
 	_default_hdr=${_default_hdr}
+	_keep_displays=${_keep_displays}
 	XDG_CURRENT_DESKTOP=${XDG_CURRENT_DESKTOP}
 	XDG_SESSION_DESKTOP=${XDG_SESSION_DESKTOP}
 	AMD_DEBUG=${AMD_DEBUG}


### PR DESCRIPTION
## Summary

This PR improves KDE display automation by:

- Ignoring disconnected DRM connectors.
- Allowing selected displays to remain enabled during streaming.
- Restoring the seat display as primary during `undo`.
- Fixing an extra closing parenthesis in the `kscreen-doctor` command.
- Fixing an uncommented text line that caused a shell error.

## Details

A new optional environment variable is supported:

```bash
DEFAULT_KEEP_DISPLAYS="DP-2 HDMI-A-1"
```

When set, these connected displays remain enabled while the stream display is active. This is useful for setups where the user wants to keep additional physical monitors available during remote streaming.

Disconnected connectors are now filtered using `/sys/class/drm/*/status`, preventing errors such as:

```text
Output with name or uuid DP-1 not found.
```

The KDE undo path now explicitly restores the seat display as primary:

```bash
kscreen-doctor output.<seat-display>.primary
```

## Validation

Tested on:

- Fedora 44
- KDE Plasma Wayland
- AMD Radeon RX 7800 XT
- Physical displays `DP-2` and `HDMI-A-1`
- Dummy display `HDMI-A-2`

Validated:

- `bash -n dpa`
- `dpa do`
- `dpa undo`
- Keeping `DP-2` and `HDMI-A-1` enabled during streaming
- Restoring `DP-2` as the primary display
- Disabling `HDMI-A-2` after the stream
- No errors for disconnected `DP-1`

## Example

```bash
DEFAULT_SEAT_DISPLAY=DP-2 \\
DEFAULT_STREAM_DISPLAY=HDMI-A-2 \\
DEFAULT_KEEP_DISPLAYS="DP-2 HDMI-A-1" \\
./dpa do
```

The default behavior remains unchanged when `DEFAULT_KEEP_DISPLAYS` is not set.
